### PR TITLE
fix sort value resetting

### DIFF
--- a/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
+++ b/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
@@ -19,11 +19,10 @@ class Meanbee_BestSellerSort_Model_Attributes extends Mage_Core_Model_Abstract
          * - Avoids nulls being shown before all products when ordered ascendingly
          */
         $productCollection = Mage::getResourceModel('catalog/product_collection')
-                           ->addAttributeToFilter(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED,
-                               array('neq' => 0)
-                           );
+                ->addAttributeToSelect(array(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED));
 
-        foreach($productCollection as $product) {
+        foreach ($productCollection as $product)
+        {
             $product->setData(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED, 0);
             $resource->saveAttribute($product, Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);
         }


### PR DESCRIPTION
If the attribute is not filled, no products will be found with this query. This will result in a wrong product order.
For performance reasons you could add a if condition in the foreach.