### PR TITLE
fixed wrong sorting for products with zero sales

### DIFF
--- a/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
+++ b/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
@@ -20,7 +20,7 @@ class Meanbee_BestSellerSort_Model_Attributes extends Mage_Core_Model_Abstract
          */
         $productCollection = Mage::getResourceModel('catalog/product_collection')
                            ->addAttributeToFilter(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED,
-                               array('neq' => 0)
+                               array(array('neq' => 0), array('null' => true)), 'left'
                            );
 
         foreach($productCollection as $product) {


### PR DESCRIPTION
Products with no `bestseller` value yet are not included in the table `catalog_product_entity_int`. There value for the `bestseller` attribute is `NULL`. Since `addAttributeToFilter` leads to an inner join by default, these products would not get a default `bestseller` value of `0`. This PR fixes the issue by changing the `joinType` to `left` and by selecting null values as well.