### PR TITLE
fixed calculation for configurable products

### DIFF
--- a/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
+++ b/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
@@ -34,13 +34,17 @@ class Meanbee_BestSellerSort_Model_Attributes extends Mage_Core_Model_Abstract
          * the most popular products are shown first
          */
 
+        $productIds = Mage::getModel('catalog/product')->getCollection()->getAllIds();
         /* @var $soldCollection Mage_Reports_Model_Mysql4_Product_Collection */
         $soldCollection = Mage::getResourceModel('reports/product_collection')
             ->addOrderedQty($this->_getFromDate($helper->getQtyOrderedAge()), $this->_getToday());
 
         foreach($soldCollection as $product) {
-            $product->setData(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED, -((int)$product->getData('ordered_qty')));
-            $resource->saveAttribute($product, Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);
+            // check if the product still exists as it could have been removed in the meantime
+            if (in_array($product->getEntityId(), $productIds)) {
+                $product->setData(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED, -((int)$product->getData('ordered_qty')));
+                $resource->saveAttribute($product, Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);
+            }
         }
 
         $this->_updateFlatProductTable(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);

--- a/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
+++ b/app/code/community/Meanbee/BestSellerSort/Model/Attributes.php
@@ -36,39 +36,11 @@ class Meanbee_BestSellerSort_Model_Attributes extends Mage_Core_Model_Abstract
 
         /* @var $soldCollection Mage_Reports_Model_Mysql4_Product_Collection */
         $soldCollection = Mage::getResourceModel('reports/product_collection')
-            ->addOrderedQty($this->_getFromDate($helper->getQtyOrderedAge()), $this->_getToday())
-            ->addFieldToFilter('sku', array('notnull' => true));
+            ->addOrderedQty($this->_getFromDate($helper->getQtyOrderedAge()), $this->_getToday());
 
         foreach($soldCollection as $product) {
             $product->setData(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED, -((int)$product->getData('ordered_qty')));
             $resource->saveAttribute($product, Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);
-        }
-
-        /**
-         * Next loop through configurable products and set their sold counts to
-         * the negative sum of their associated products.
-         */
-        $configurableCollection = Mage::getResourceModel('catalog/product_collection')
-              ->addFieldToFilter('type_id', array('eq' => Mage_Catalog_Model_Product_Type_Configurable::TYPE_CODE));
-
-        $childrenIds = array();
-        foreach ($configurableCollection as $parent) {
-            $childrenIds[$parent->getId()] = $parent->getTypeInstance()->getUsedProductIds();
-        }
-        $flatChildrenIds = array();
-        array_walk_recursive($childrenIds,
-                             function($id) use (&$flatChildrenIds) { $flatChildrenIds[] = $id; }
-                            );
-        $children = Mage::getResourceModel('catalog/product_collection')
-                  ->addAttributeToSelect(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED)
-                  ->addFieldToFilter('entity_id', array('in' => $flatChildrenIds));
-        foreach ($configurableCollection as $parent) {
-            $total = 0;
-            foreach ($childrenIds[$parent->getId()] as $childId) {
-                $total -= $children->getItemById($childId)->getData(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);
-            }
-            $parent->setData(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED, $total);
-            $resource->saveAttribute($parent, Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);
         }
 
         $this->_updateFlatProductTable(Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);


### PR DESCRIPTION
The `reports/product_collection` does NOT include simple products if they are sold as an option of a configurable product. Hence, currently, the `bestseller` attribute for all configurable products is `0`.

However, the `reports/product_collection` already DOES include the aggregated sales for configurable (and for bundle) products. You can even see this in the backend under Reports > Products > Products Ordered. They have an empty `sku` value, but this is not important to us. The `entity_id` is correct, so that the `$resource->saveAttribute($product, Meanbee_BestSellerSort_Helper_Data::ATTRIBUTE_NAME_QTY_ORDERED);` works nevertheless.

This PR fixes #3.